### PR TITLE
Update git repo

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: install codebase
   git:
-     repo: https://bitbucket.org/automationlogic/ubuntu_build.git
+     repo: https://github.com/UKHomeOffice/hmpo-laptops-public.git
      dest: /home/ansible/ansible
      update: yes
 


### PR DESCRIPTION
The bitbucket.org repo is being deprecated so this URL needs to be
updated as this is the last reference contained in this repo.