### PR TITLE
Modify url used by Ansible task

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: install codebase
   git:
-     repo: https://bitbucket.org/automationlogic/ubuntu_build.git
+     repo: https://github.com/UKHomeOffice/hmpo-laptops-public.git
      dest: /home/ansible/ansible
      update: yes
 


### PR DESCRIPTION
This url is deprecated and hopefully this task in ansible will soon be
removed as it's unnessary coupling of code.